### PR TITLE
Add ability to use lockfile directly

### DIFF
--- a/lib/chef-berksfile-env.rb
+++ b/lib/chef-berksfile-env.rb
@@ -6,6 +6,17 @@ require 'pathname'
 class Chef
   class Environment
 
+    # @param path path to lock file
+    # @raise Berkshelf::LockfileNotFound exception
+    def load_berksfile_lock(path=nil)
+      lockfile = ::Berkshelf::Lockfile.from_file(path)
+      raise ::Berkshelf::LockfileNotFound, "Berks lock file is not present: #{path}" unless lockfile.present?
+
+      lockfile.locks.each_pair do |_, dependency|
+        cookbook dependency.name, "= #{dependency.locked_version.to_s}"
+      end
+    end
+
     def load_berksfile(path=nil)
       raise "You must define the environment name before doing load_berksfile" if path.nil? && name.empty?
       


### PR DESCRIPTION
It gives good possibility to update environment from CI server.
Method load_berksfile_lock skips all validations and uses lock file directly.
For example CI server always requires to do `berks install` because, some of cookbooks might be not present on CI server. Also this works much faster.

Also, I think its better to not modify or auto-complete *path*. Because an `chef-environment.rb` is a ruby file, we always able to calculate right path to Berkshelf or Berkshelf.lock.

In our case we're have `environments` folder in chef repo. Each environment described by 3 files:
* \<environment-name\> - berksfile
* \<environment-name\>.rb - chef environment file
* \<environment-name\>.lock - berksfile lock

staging:
```ruby
source 'https://supermarket.chef.io'
source 'http://company-berkshelf-api'

group :common do
  cookbook 'proj-base'
  cookbook 'proj-java', '~> 2.0'
  cookbook 'proj-chef', '~> 0.1'
end

group :balancer do
  cookbook 'proj-haproxy', '~> 2.4'
end
```

staging.rb
```ruby
require 'chef-berksfile-env'

name 'staging'
default_attributes(...)
override_attributes(...)
# Cookbook Constraints from Berksfile
load_berksfile File.basename(__FILE__, '.rb')
# or with this PR
# load_berksfile_lock File.basename(__FILE__, '.rb') + '.lock'
```

Now you can do something like:
```bash
berks install -b staging # resolve all
berks update chef -b dev # update chef on dev
knife environment from file staging.rb # apply env
berks apply staging -b staging.lock # trick to update only versions
```

